### PR TITLE
Finite element implementation, assembly, BCs

### DIFF
--- a/main.tex
+++ b/main.tex
@@ -1219,7 +1219,7 @@ Galerkin schemes are based on discrete approximation spaces, which may or may no
 %     \end{proof}
 % \end{lemma}
 
-In order to have a good approximation, it is not necessary that the scheme is conforming. Some examples of conforming schemes are most finite element methods and spectral element methods, and among non-conforming schemes are discontinuous-Galerkin (DG) finite element methods, and methods that impose boundary conditions weakly. We will study several conforming finite element methods in Section \ref{sec:fem}. 
+In order to have a good approximation, it is not necessary that the scheme is conforming. Some examples of conforming schemes are most finite element methods and spectral element methods, and among non-conforming schemes are discontinuous-Galerkin (DG) finite element methods, and methods that impose boundary conditions weakly. We will study several conforming finite element methods in Section~\ref{sec:fem}. 
 
 Although conforming spaces have some nice properties, there exist some applications where the mesh and the domain boundaries may not match, or where traditional finite elements may not apply, forcing one to use other schemes such as spline-based methods, where the degrees of freedom are control points of the splines, rather than actual nodes. In these cases, we can use a non-conforming scheme. The following presentation is based on \cite{Chouly2024}. Consider the Poisson problem with a nonhomogeneous Dirichlet boundary condition: find $u:\Omega\to \mathbb{R}$ such that
 $$
@@ -1281,33 +1281,33 @@ In what follows, the intervals $I_i$ are also called elements (or cells) and the
 
 \subsubsection{The $\mathbb{P}_1$ Lagrange finite element}
 One of the simplest methods to approximate functions over $\Omega$ is to define piecewise-linear functions. We denote the vector space of continuous, piecewise-linear functions
-$$ \mathbb{P}_h^1 = \{ v_h \in C(\bar{\Omega}): \forall i \in \{0, \dots, N\}, v_h|_{I_i} \in \mathbb{P}_1 \},$$
-where $\mathbb{P}_d$ is the vector space of polynomials of degree $d$. This space can be used in conjunction with Galerkin methods to approximate one-dimensional PDEs, and for this reason, $\mathbb{P}_h^1$ is called an approximation space.
+$$ P_h^1 = \{ v_h \in C(\bar{\Omega}): \forall i \in \{0, \dots, N\}, v_h|_{I_i} \in \mathbb{P}_1 \}.$$
+This space can be used in conjunction with Galerkin methods to approximate one-dimensional PDEs, and for this reason, $P_h^1$ is called an approximation space.
 We introduce the functions $\{\varphi_0, \dots, \varphi_{N+1}\}$ defined elementwise as follows: for $i \in \{0, \dots, N+1\}$, set
 $$ \varphi_i(x) = \begin{cases} \frac{x - x_{i-1}}{h_{i-1}} & \text{if } x \in I_{i-1}, \\ \frac{x_{i+1} - x}{h_i} & \text{if } x \in I_i, \\ 0 & \text{otherwise}, \end{cases} $$
-with obvious modifications if $i = 0$ or $N+1$. Clearly, $\varphi_i \in \mathbb{P}_h^1$. These functions are often called ''hat functions'' in reference to the shape of their graph.
+with obvious modifications if $i = 0$ or $N+1$. Clearly, $\varphi_i \in P_h^1$. These functions are often called ''hat functions'' in reference to the shape of their graph.
 \begin{lemma} \label{hatbasis}
-    The set $\{\varphi_0, \dots, \varphi_{N+1}\}$ is a basis for $\mathbb{P}_h^1$.
+    The set $\{\varphi_0, \dots, \varphi_{N+1}\}$ is a basis for $P_h^1$.
     \begin{proof}
-        The proof relies on the fact that $\varphi_i(x_j) = \delta_{ij}$ where $\delta$ is the Kronecker delta, for $0 \le i,j \le N+1$. Let $(a_0, \dots, a_{N+1})^\top \in \mathbb{R}^{N+2}$ and assume that the continuous function $w = \sum_{i=0}^{N+1} a_i \varphi_i$ vanishes identically in $\bar{\Omega}$. Then, for $0 \le i \le N+1$, $a_i = w(x_i) = 0$; hence, the set $\{\varphi_0, \dots, \varphi_{N+1}\}$ is linearly independent. Furthermore, for all $v_h \in \mathbb{P}_h^1$, it is clear that $v_h = \sum_{i=0}^{N+1} v_h(x_i) \varphi_i$ since, on each element $I_i$, the functions $v_h$ and $\sum_{i=0}^{N+1} v_h(x_i) \varphi_i$ are affine and coincide at two points, namely $x_i$ and $x_{i+1}$.
+        The proof relies on the fact that $\varphi_i(x_j) = \delta_{ij}$ where $\delta$ is the Kronecker delta, for $0 \le i,j \le N+1$. Let $(a_0, \dots, a_{N+1})^\top \in \mathbb{R}^{N+2}$ and assume that the continuous function $w = \sum_{i=0}^{N+1} a_i \varphi_i$ vanishes identically in $\bar{\Omega}$. Then, for $0 \le i \le N+1$, $a_i = w(x_i) = 0$; hence, the set $\{\varphi_0, \dots, \varphi_{N+1}\}$ is linearly independent. Furthermore, for all $v_h \in P_h^1$, it is clear that $v_h = \sum_{i=0}^{N+1} v_h(x_i) \varphi_i$ since, on each element $I_i$, the functions $v_h$ and $\sum_{i=0}^{N+1} v_h(x_i) \varphi_i$ are affine and coincide at two points, namely $x_i$ and $x_{i+1}$.
     \end{proof}
 \end{lemma}
 \begin{definition}
-    Choose a basis $\{\gamma_0, \dots, \gamma_{N+1}\}$ for $\mathcal{L}(\mathbb{P}_h^1;\mathbb{R})$; henceforth, the linear forms in this basis are called the global degrees of freedom in $\mathbb{P}_h^1$. The functions in the dual basis are called the global shape functions in $\mathbb{P}_h^1$. 
+    Choose a basis $\{\gamma_0, \dots, \gamma_{N+1}\}$ for $\mathcal{L}(P_h^1;\mathbb{R})$; henceforth, the linear forms in this basis are called the global degrees of freedom in $P_h^1$. The functions in the dual basis are called the global shape functions in $P_h^1$. 
 \end{definition}
 For $i \in \{0, \dots, N+1\}$, choose the linear form
-$$ \gamma_i: C(\bar{\Omega}) \ni v \mapsto \gamma_i(v) = v(x_i) \in \mathbb{R} $$.
-The proof of \ref{hatbasis} shows that a function $v_h \in \mathbb{P}_h^1$ is uniquely defined by the $(N+2)$-uplet $(v_h(x_i))_{0 \le i \le N+1}$, i.e. the values at the nodes. In other words, $\{\gamma_0, \dots, \gamma_{N+1}\}$ is a basis for $\mathcal{L}(\mathbb{P}_h^1; \mathbb{R})$. Choosing the linear forms $\{\gamma_i\}_i$ defined above as the global degrees of freedom in $\mathbb{P}_h^1$, the global shape functions are precisely the hat functions $\{\varphi_0, \dots, \varphi_{N+1}\}$, since $\gamma_i(\varphi_j) = \delta_{ij}$, $0 \le i,j \le N+1$.
+$$ \gamma_i: C(\bar{\Omega}) \ni v \mapsto \gamma_i(v) = v(x_i) \in \mathbb{R}.$$
+The proof of Lemma~\ref{hatbasis} shows that a function $v_h \in P_h^1$ is uniquely defined by the $(N+2)$-uplet $(v_h(x_i))_{0 \le i \le N+1}$, i.e. the values at the nodes. In other words, $\{\gamma_0, \dots, \gamma_{N+1}\}$ is a basis for $\mathcal{L}(P_h^1; \mathbb{R})$. Choosing the linear forms $\{\gamma_i\}_i$ defined above as the global degrees of freedom in $P_h^1$, the global shape functions are precisely the hat functions $\{\varphi_0, \dots, \varphi_{N+1}\}$, since $\gamma_i(\varphi_j) = \delta_{ij}$, $0 \le i,j \le N+1$.
 
 In this space, we define the interpolation operator
-$$ I_h^1: C(\bar{\Omega}) \ni v \mapsto \sum_{i=0}^{N+1} \gamma_i(v) \varphi_i \in \mathbb{P}_h^1.$$
-For a function $v \in C^0(\bar{\Omega})$, $I_h^1 v$ is the unique continuous, piecewise linear function that takes the same value as $v$ at all the mesh vertices. The function $I_h^1 v$ is called the Lagrange interpolant of $v$ of degree 1. Note that the approximation space $\mathbb{P}_h^1$ is the codomain of $I_h^1$. 
+$$ I_h^1: C(\bar{\Omega}) \ni v \mapsto \sum_{i=0}^{N+1} \gamma_i(v) \varphi_i \in P_h^1.$$
+For a function $v \in C^0(\bar{\Omega})$, $I_h^1 v$ is the unique continuous, piecewise linear function that takes the same value as $v$ at all the mesh vertices. The function $I_h^1 v$ is called the Lagrange interpolant of $v$ of degree 1. Note that the approximation space $P_h^1$ is the codomain of $I_h^1$. 
 
 Now we connect the polynomial approximation space we just defined with the Sobolev space $H^1(\Omega)$, to ensure that our method is conforming. 
 \begin{lemma}\label{approxP1}
-    It holds that $\mathbb{P}_h^1 \subset H^1(\Omega)$.
+    It holds that $P_h^1 \subset H^1(\Omega)$.
     \begin{proof}
-    Let $v_h \in \mathbb{P}_h^1$. Clearly, $v_h \in L^2(\Omega)$. Furthermore, owing to the continuity of $v_h$, its first-order distributional derivative is the piecewise constant function $w_h$ such that
+    Let $v_h \in P_h^1$. Clearly, $v_h \in L^2(\Omega)$. Furthermore, owing to the continuity of $v_h$, its first-order distributional derivative is the piecewise constant function $w_h$ such that
     $$\forall I_i \in \mathcal{T}_h,\quad  w_h|_{I_i} = \frac{v_h(x_{i+1}) - v_h(x_i)}{h_i}.$$
     It is clear that $w_h\in L^2(\Omega)$, and thus by definition we conclude $v_h\in H^1(\Omega)$.
     \end{proof}
@@ -1321,8 +1321,10 @@ We can characterize the properties of the interpolation operator.
         |v(y) - v(x)| \le \int_x^y |v'(s)| ds  \le |y-x|^{1/2} |v|_{1,\Omega},
     \end{equation*}
     owing to the Cauchy-Schwarz inequality, which can be justified rigorously by a density argument. Furthermore, taking $x$ to be a point where $|v|$ reaches its minimum over $\overline{\Omega}$, the above inequality implies
-    $$ \|v\|_{L^\infty(\Omega)} \le |b-a|^{-1/2} \|v\|_0 + |b-a|^{1/2}|v|_{1,\Omega},$$
-    since $|v(x)| \le |b-a|^{-1/2} \|v\|_{0}$. Therefore, $I_h^1 v$ is well-defined for $v \in H^1(\Omega)$. Moreover, Lemma \ref{approxP1} implies $I_h^1 v \in H^1(\Omega)$; hence, $I_h^1$ maps $H^1(\Omega)$ to $H^1(\Omega)$.
+    \begin{equation*}\label{eq:supnorm_p1}
+        \|v\|_{L^\infty(\Omega)} \le |b-a|^{-1/2} \|v\|_0 + |b-a|^{1/2}|v|_{1,\Omega},
+    \end{equation*}
+    since $|v(x)| \le |b-a|^{-1/2} \|v\|_{0}$. Therefore, $I_h^1 v$ is well-defined for $v \in H^1(\Omega)$. Moreover, Lemma~\ref{approxP1} implies $I_h^1 v \in H^1(\Omega)$; hence, $I_h^1$ maps $H^1(\Omega)$ to $H^1(\Omega)$.
     For the second part, let $I_i \in \mathcal{T}_h$ for $0 \le i \le N$. From the definition of the distributional derivative $w_h$ above, $(I_h^1 v)'|_{I_i} = h_i^{-1}(v(x_{i+1}) - v(x_i))$; hence, using the previous inequality we get the estimate $|I_h^1 v|_{1,I_i} \le |v|_{1,I_i}$. Therefore, $|I_h^1 v|_{1,\Omega} \le |v|_{1,\Omega}$. Moreover, since $\|I_h^1 v\|_{0,\Omega} \le |b-a|^{1/2} \|I_h^1 v\|_{L^\infty(\Omega)}$ and $\|I_h^1 v\|_{L^\infty(\Omega)} \le \|v\|_{L^\infty(\Omega)}$, we deduce that $\|I_h^1 v\|_{0,\Omega} \le c \|v\|_{1,\Omega}$ where $c$ is independent of $h$ (assuming $h$ bounded). The conclusion follows readily.
     \end{proof}
 \end{lemma}
@@ -1331,7 +1333,7 @@ We can explicitly control the interpolation error via the mesh size.
     For all $h$ and $v \in H^2(\Omega)$,
     $$ \|v - I_h^1 v\|_{0,\Omega} \le h^2 \|v''\|_{0,\Omega},\qquad  |v - I_h^1 v|_{1,\Omega} \le h \|v''\|_{0,\Omega}. $$
 \begin{proof}
-    Consider an interval $I_i \in \mathcal{T}_h$. Let $w \in H^1(I_i)$ be such that $w$ vanishes at some point $\xi$ in $I_i$. Then, owing to \ref{interpolator_continuity_1d}, we infer $\|w\|_{0,I_i} \le h_i |w|_{1,I_i}$.
+    Consider an interval $I_i \in \mathcal{T}_h$. Let $w \in H^1(I_i)$ be such that $w$ vanishes at some point $\xi$ in $I_i$. Then, owing to inequality~\ref{eq:interpolator_continuity_1d}, we infer $\|w\|_{0,I_i} \le h_i |w|_{1,I_i}$.
     Let $v \in H^2(\Omega)$, let $i \in \{0, \dots, N\}$, and set $w_i = (v - I_h^1 v)'|_{I_i}$. Note that $w_i \in H^1(I_i)$ and that $w_i$ vanishes at some point $\xi$ in $I_i$ owing to the mean-value theorem. Applying the estimate derived above to $w_i$ and using the fact that $(I_h^1 v)''$ vanishes identically on $I_i$ yields $|v - I_h^1 v|_{1,I_i} \le h_i |v''|_{0,I_i}$. The second estimate is then obtained by summing over the mesh intervals. To prove the first estimate, observe that the result above can also be applied to $(v - I_h^1 v)|_{I_i}$ yielding
     $$ \|v - I_h^1 v\|_{0,I_i} \le h_i |v - I_h^1 v|_{1,I_i} \le h_i^2 |v''|_{0,I_i}. $$
     Conclude by summing over the mesh intervals.
@@ -1353,8 +1355,8 @@ $$ \|v - \mathcal{I}_{I_i}^1 v\|_{0,I_i} \le h_i^2 |v|_{2,I_i},\qquad|\mathcal{I
 
 \subsubsection{The $\mathbb{P}_k$ Lagrange finite elements}
 The interpolation technique presented for the piecewise-linear case (polynomial degree $1$) generalizes to higher-degree polynomials. Consider the mesh $\mathcal{T}_h = \{I_i\}_{0 \le i \le N}$ introduced previously. Let
-$$ \mathbb{P}_h^k = \{ v_h \in C(\bar{\Omega}): \forall i \in \{0, \dots, N\}, v_h|_{I_i} \in \mathbb{P}_k \}. $$
-To investigate the properties of the approximation space $\mathbb{P}_h^k$ and to construct an interpolation operator with codomain $\mathbb{P}_h^k$, it is convenient to consider Lagrange polynomials. Recall the following:
+$$ P_h^k = \{ v_h \in C(\bar{\Omega}): \forall i \in \{0, \dots, N\}, v_h|_{I_i} \in \mathbb{P}_k \}. $$
+To investigate the properties of the approximation space $P_h^k$ and to construct an interpolation operator with codomain $P_h^k$, it is convenient to consider Lagrange polynomials. Recall the following:
 
 \begin{definition}[Lagrange polynomials]\label{def:lagrangepolynomials}
     Let $k \ge 1$ and let $\{s_0, \dots, s_k\}$ be $(k+1)$ distinct numbers. The Lagrange polynomials $\{\mathcal{L}_0^k, \dots, \mathcal{L}_k^k\}$ associated with the nodes $\{s_0, \dots, s_k\}$ are defined to be
@@ -1368,31 +1370,31 @@ and for $m=0$,
 $$ \varphi_{ki}(x) = \begin{cases} \mathcal{L}_{i-1,k}^k(x) & \text{if } x \in I_{i-1}, \\ \mathcal{L}_{i,0}^k(x) & \text{if } x \in I_i, \\ 0 & \text{otherwise}, \end{cases} $$
 with obvious modifications if $i = 0$ or $N+1$.
 \begin{lemma}\label{basis_functions_Pk}
-    The construction above results in degree $k$ polynomials, i.e. $\varphi_j \in \mathbb{P}_h^k$.
+    The construction above results in degree $k$ polynomials, i.e. $\varphi_j \in P_h^k$.
 \begin{proof}
-    Let $j \in \{0, \dots, k(N+1)\}$ with $j = ki + m.$ If $1 \le m \le k-1$, $\varphi_j(x_i) = \varphi_j(x_{i+1}) = 0$; hence, $\varphi_j \in C(\bar{\Omega})$. Moreover, the restrictions of $\varphi_j$ to the mesh intervals are in $\mathbb{P}_k$ by construction. Therefore, $\varphi_j \in \mathbb{P}_h^k$. Now, assume $m = 0$ (i.e., $j=ki$) and $0 < i < N+1$. Clearly, $\varphi_{ki}$ is continuous at $x_i$ by construction and $\varphi_{ki}(x_{i-1}) = \varphi_{ki}(x_{i+1}) = 0$; hence, $\varphi_{ki} \in \mathbb{P}_h^k$. The cases $i = 0$ and $i = N+1$ are treated similarly.
+    Let $j \in \{0, \dots, k(N+1)\}$ with $j = ki + m.$ If $1 \le m \le k-1$, $\varphi_j(x_i) = \varphi_j(x_{i+1}) = 0$; hence, $\varphi_j \in C(\bar{\Omega})$. Moreover, the restrictions of $\varphi_j$ to the mesh intervals are in $\mathbb{P}_k$ by construction. Therefore, $\varphi_j \in P_h^k$. Now, assume $m = 0$ (i.e., $j=ki$) and $0 < i < N+1$. Clearly, $\varphi_{ki}$ is continuous at $x_i$ by construction and $\varphi_{ki}(x_{i-1}) = \varphi_{ki}(x_{i+1}) = 0$; hence, $\varphi_{ki} \in P_h^k$. The cases $i = 0$ and $i = N+1$ are treated similarly.
 \end{proof}
 \end{lemma}
 Introduce the set of nodes $\{a_j\}_{0 \le j \le k(N+1)}$ such that $a_j = \xi_{i,m}$ where $j = ik + m$. For $j \in \{0, \dots, k(N+1)\}$, consider the linear form
 $$ \gamma_j: C(\bar{\Omega}) \ni v \mapsto \gamma_j(v) = v(a_j). $$
 
 \begin{lemma}
-    $\{\varphi_0, \dots, \varphi_{k(N+1)}\}$ is a basis for $\mathbb{P}_h^k$, and $\{\gamma_0, \dots, \gamma_{k(N+1)}\}$ is a basis for $\mathcal{L}(\mathbb{P}_h^k; \mathbb{R})$.
+    $\{\varphi_0, \dots, \varphi_{k(N+1)}\}$ is a basis for $P_h^k$, and $\{\gamma_0, \dots, \gamma_{k(N+1)}\}$ is a basis for $\mathcal{L}(P_h^k; \mathbb{R})$.
 
 \begin{proof}
-    Similar to that of Lemma \ref{hatbasis}, since $\gamma_j(\varphi_{j'}) = \delta_{jj'}$ for $0 \le j,j' \le k(N+1)$.
+    Similar to that of Lemma~\ref{hatbasis}, since $\gamma_j(\varphi_{j'}) = \delta_{jj'}$ for $0 \le j,j' \le k(N+1)$.
 \end{proof}
 \end{lemma}
-The global degrees of freedom in $\mathbb{P}_h^k$ are chosen to be the $(k(N+1)+1)$ linear forms $\gamma_j$ defined above; hence, the global shape functions in $\mathbb{P}_h^k$ are the functions $\{\varphi_0, \dots, \varphi_{k(N+1)}\}$.
+The global degrees of freedom in $P_h^k$ are chosen to be the $(k(N+1)+1)$ linear forms $\gamma_j$ defined above; hence, the global shape functions in $P_h^k$ are the functions $\{\varphi_0, \dots, \varphi_{k(N+1)}\}$.
 
 The main advantage of using high-degree polynomials is that smooth functions can be interpolated to high-order accuracy. Define the interpolation operator $I_h^k$ to be
-$$ I_h^k: C(\bar{\Omega}) \ni v \mapsto \sum_{j=0}^{k(N+1)} \gamma_j(v) \varphi_j \in \mathbb{P}_h^k. $$
-$I_h^k v$ is called the Lagrange interpolant of $v$ of degree $k$. Clearly, $I_h^k$ is a linear operator, and $I_h^k v$ is the unique function in $\mathbb{P}_h^k$ that takes the same value as $v$ at all the mesh nodes. The approximation space $\mathbb{P}_h^k$ is the codomain of $I_h^k$. 
+$$ I_h^k: C(\bar{\Omega}) \ni v \mapsto \sum_{j=0}^{k(N+1)} \gamma_j(v) \varphi_j \in P_h^k. $$
+$I_h^k v$ is called the Lagrange interpolant of $v$ of degree $k$. Clearly, $I_h^k$ is a linear operator, and $I_h^k v$ is the unique function in $P_h^k$ that takes the same value as $v$ at all the mesh nodes. The approximation space $P_h^k$ is the codomain of $I_h^k$. 
 
 \begin{lemma}
-    The approximation space $\mathbb{P}_h^k$ constructed above satisfies $\mathbb{P}_h^k \subset H^1(\Omega)$.
+    The approximation space $P_h^k$ constructed above satisfies $P_h^k \subset H^1(\Omega)$.
 \begin{proof}
-    Similar to that of Lemma \ref{approxP1}.
+    Similar to that of Lemma~\ref{approxP1}.
 \end{proof}
 \end{lemma}
 To investigate the properties of $I_h^k$, it is convenient to introduce a family of local interpolation operators. On $I_i = [x_i, x_{i+1}] \in \mathcal{T}_h$ choose the local degrees of freedom to be the $(k+1)$ linear forms $\{\sigma_{i,0}, \dots, \sigma_{i,k}\}$ defined as follows:
@@ -1416,20 +1418,20 @@ Since $T_i(\hat{K}) = I_i$, the mesh $\mathcal{T}_h$ can be constructed by apply
 \end{align*}
 and thus we infer
 $$ \forall v \in C(I_i), \quad \mathcal{I}_{I_i}^k(v) \circ T_i = \mathcal{I}_{\hat{K}}^k(v \circ T_i). $$
-In other words, the family $\{\mathcal{I}_{I_i}^k\}_{I_i \in \mathcal{T}_h}$ is entirely generated by the transformations $\{T_i\}_{I_i \in \mathcal{T}_h}$ and the reference interpolation operator $\mathcal{I}_{\hat{K}}^k$. The property above plays a key role when estimating the interpolation error; see the proof of Lemma \ref{interpolationerrPk} below.
+In other words, the family $\{\mathcal{I}_{I_i}^k\}_{I_i \in \mathcal{T}_h}$ is entirely generated by the transformations $\{T_i\}_{I_i \in \mathcal{T}_h}$ and the reference interpolation operator $\mathcal{I}_{\hat{K}}^k$. The property above plays a key role when estimating the interpolation error; see the proof of Lemma~\ref{interpolationerrPk} below.
 
 As well as with the one-dimensional case, we can characterize the interpolation operators.
 \begin{lemma}
     $I_h^k$ is a linear continuous mapping from $H^1(\Omega)$ to $H^1(\Omega)$, and $\|I_h^k\|_{\mathcal{L}(H^1(\Omega);H^1(\Omega))}$ is uniformly bounded with respect to $h$.
 \begin{proof}
-    To prove that $I_h^k$ maps $H^1(\Omega)$ to $H^1(\Omega)$, use the same argument as in the proof of Lemma \ref{cont1D}.
+    To prove that $I_h^k$ maps $H^1(\Omega)$ to $H^1(\Omega)$, use the same argument as in the proof of Lemma~\ref{cont1D}.
     Let $v \in H^1(\Omega)$ and $I_i \in \mathcal{T}_h$. Since $\sum_{m=0}^k \theta_{i,m}' = 0$,
     $$ (\mathcal{I}_{I_i}^k v)' = \sum_{m=0}^k [v(\xi_{i,m}) - v(x_i)] \theta_{i,m}'. $$
-    Inequality \ref{eq:interpolator_continuity_1d} yields $|v(\xi_{i,m}) - v(x_i)| \le h_i^{1/2} |v|_{1,I_i}$ for $0 \le m \le k$. Furthermore, changing variables in the integral, it is clear that $|\theta_{i,m}|_{1,I_i} = h_i^{-1/2} |\hat{\theta}_m|_{1,\hat{K}}$. Set $c_k = \max_{0 \le m \le k} |\hat{\theta}_m|_{1,\hat{K}}$ and observe that this quantity is mesh-independent. A straightforward calculation yields
+    Inequality~\ref{eq:interpolator_continuity_1d} yields $|v(\xi_{i,m}) - v(x_i)| \le h_i^{1/2} |v|_{1,I_i}$ for $0 \le m \le k$. Furthermore, changing variables in the integral, it is clear that $|\theta_{i,m}|_{1,I_i} = h_i^{-1/2} |\hat{\theta}_m|_{1,\hat{K}}$. Set $c_k = \max_{0 \le m \le k} |\hat{\theta}_m|_{1,\hat{K}}$ and observe that this quantity is mesh-independent. A straightforward calculation yields
     $$ |\mathcal{I}_{I_i}^k v|_{1,I_i} \le (k+1) c_k |v|_{1,I_i}, $$
     showing that $|\mathcal{I}_h^k v|_{1,\Omega}$ is controlled by $|v|_{1,\Omega}$ uniformly with respect to $h$. In addition, since $\sum_{m=0}^k \theta_{i,m} = 1$,
     $$ \mathcal{I}_{I_i}^k v - v(x_i) = \sum_{m=0}^k [v(\xi_{i,m}) - v(x_i)] \theta_{i,m}, $$
-    implying, for $x \in I_i$, $|\mathcal{I}_{I_i}^k v(x)| \le \|v\|_{L^\infty(\Omega)} + (k+1) d_k h_i^{1/2} |v|_{1,I_i}$ with the mesh-independent constant $d_k = \max_{0 \le m \le k} \|\hat{\theta}_m\|_{L^\infty(\hat{K})}$. Then, from \ref{interpolationerrPk} we get that $\|\mathcal{I}_h^k v\|_{L^\infty(\Omega)}$ is controlled by $\|v\|_{1,\Omega}$ uniformly with respect to $h$. To conclude, use the fact that $\|\mathcal{I}_h^k v\|_{0,\Omega} \le |b-a|^{1/2} \|\mathcal{I}_h^k v\|_{L^\infty(\Omega)}$.
+    implying, for $x \in I_i$, $|\mathcal{I}_{I_i}^k v(x)| \le \|v\|_{L^\infty(\Omega)} + (k+1) d_k h_i^{1/2} |v|_{1,I_i}$ with the mesh-independent constant $d_k = \max_{0 \le m \le k} \|\hat{\theta}_m\|_{L^\infty(\hat{K})}$. Then, from inequality~\ref{eq:supnorm_p1} we get that $\|\mathcal{I}_h^k v\|_{L^\infty(\Omega)}$ is controlled by $\|v\|_{1,\Omega}$ uniformly with respect to $h$. To conclude, use the fact that $\|\mathcal{I}_h^k v\|_{0,\Omega} \le |b-a|^{1/2} \|\mathcal{I}_h^k v\|_{L^\infty(\Omega)}$.
 \end{proof}
 \end{lemma}
 \begin{lemma}\label{interpolationerrPk}
@@ -1445,7 +1447,7 @@ As well as with the one-dimensional case, we can characterize the interpolation 
     Similarly, $|\hat{v}|_{l+1,\hat{K}} = h_i^{l+1/2} |v|_{l+1,I_i}$. 
     Consider the linear mapping
     $$ \mathcal{F}: H^{l+1}(\hat{K}) \ni \hat{v} \mapsto \hat{v} - \mathcal{I}_{\hat{K}}^k \hat{v} \in H^m(\hat{K}). $$
-    Note that $\mathcal{I}_{\hat{K}}^k \hat{v}$ is meaningful since in one dimension, $\hat{v} \in H^{l+1}(\hat{K})$ with $l \ge 0$ implies $\hat{v} \in C(\hat{K})$. Moreover, $\mathcal{F}$ is continuous from $H^{l+1}(\hat{K})$ to $H^m(\hat{K})$. Indeed, one can easily adapt the proof of Lemma \ref{cont1D} to prove that $\mathcal{I}_{\hat{K}}^k$ is continuous from $H^1(\hat{K})$ to $H^s(\hat{K})$ for all $s \ge 1$. Furthermore, it is clear that $\mathbb{P}_k$ is invariant under $\mathcal{F}$ since, for all $\hat{p} \in \mathbb{P}_k$ with $\hat{p} = \sum_{n=0}^k \alpha_n \hat{\theta}_n$
+    Note that $\mathcal{I}_{\hat{K}}^k \hat{v}$ is meaningful since in one dimension, $\hat{v} \in H^{l+1}(\hat{K})$ with $l \ge 0$ implies $\hat{v} \in C(\hat{K})$. Moreover, $\mathcal{F}$ is continuous from $H^{l+1}(\hat{K})$ to $H^m(\hat{K})$. Indeed, one can easily adapt the proof of Lemma~\ref{cont1D} to prove that $\mathcal{I}_{\hat{K}}^k$ is continuous from $H^1(\hat{K})$ to $H^s(\hat{K})$ for all $s \ge 1$. Furthermore, it is clear that $\mathbb{P}_k$ is invariant under $\mathcal{F}$ since, for all $\hat{p} \in \mathbb{P}_k$ with $\hat{p} = \sum_{n=0}^k \alpha_n \hat{\theta}_n$
     $$ \mathcal{I}_{\hat{K}} \hat{p} = \sum_{m,n=0}^k \alpha_n \hat{\sigma}_m(\hat{\theta}_n) \hat{\theta}_m = \sum_{m,n=0}^k \alpha_n \delta_{mn} \hat{\theta}_m = \sum_{n=0}^k \alpha_n \hat{\theta}_n = \hat{p}. $$
     Since $l \le k$, $\mathbb{P}_l$ is invariant under $\mathcal{F}$. As a result,
     \begin{align*}
@@ -1455,7 +1457,7 @@ As well as with the one-dimensional case, we can characterize the interpolation 
     \end{align*}
     the last estimate resulting from the Deny-Lions Lemma; see Lemma B.67 in \cite{ern2004theory}. The identities derived in step 1 yield
     $$ |v - \mathcal{I}_{I_i}^k v|_{m,I_i} = h_i^{-m+1/2} |\hat{v} - \mathcal{I}_{\hat{K}}^k \hat{v}|_{m,\hat{K}} \le h_i^{-m+1/2} c |\hat{v}|_{l+1,\hat{K}} = h_i^{-m+1/2} c h_i^{l+1/2} |v|_{l+1,I_i} = c h_i^{l+1-m} |v|_{l+1,I_i}. $$
-    To derive the desired, sum over the mesh intervals. When $m = 0$ or 1, global norms over $\Omega$ can be used since $\mathbb{P}_k \subset H^1(\Omega)$ owing to the fact that $\mathbb{P}_h^k\subset H^1(\Omega)$.
+    To derive the desired, sum over the mesh intervals. When $m = 0$ or 1, global norms over $\Omega$ can be used since $\mathbb{P}_k \subset H^1(\Omega)$ owing to the fact that $P_h^k\subset H^1(\Omega)$.
 \end{proof}
 \end{lemma}
 Note that the proofs above show that the interpolation properties of $I_h^k$ are local. If the function to be interpolated is smooth enough, say $v \in H^{k+1}(\Omega)$, the interpolation error is of optimal order. In particular, the first error estimate yields
@@ -1493,7 +1495,7 @@ With one-dimensional interpolation already covered, we now present a general def
     $\{\theta_1, \dots, \theta_{n_{sh}}\}$ are called the local shape functions.
 \end{definition}
 
-Note that condition (3) in Definition \ref{def:finiteelements} amounts to proving that
+Note that condition (3) in Definition~\ref{def:finiteelements} amounts to proving that
     $$ \forall(\alpha_1, \dots, \alpha_{n_{sh}}) \in \mathbb{R}^{n_{sh}}, \quad \exists ! p \in P, \quad \sigma_i(p) = \alpha_i \text{ for } 1 \le i \le n_{sh}, $$
     which, in turn, is equivalent to
     $$ \begin{cases} \dim P = |\Sigma| = n_{sh}, \\ \forall p \in P, (\sigma_i(p) = 0, 1 \le i \le n_{sh}) \Rightarrow (p = 0). \end{cases} $$
@@ -1528,7 +1530,7 @@ $V(K)$ is the domain of $\mathcal{I}_K$ and $P$ is its codomain. Note that the t
     i.e., the Lagrange interpolant is constructed by matching the point values at the Lagrange nodes.
 }
 
-At this point, it may seem more appropriate to define a finite element as a quadruplet $\{K, P, \Sigma, V(K)\}$ where the triplet $\{K, P, \Sigma\}$ complies with Definition \ref{def:finiteelements} and $V(K)$ satisfies properties (1)-(2). However, for the sake of simplicity, we hereafter employ the well-established triplet-based definition, and always implicitly assume that there exists a normed vector space $V(K)$ satisfying properties (1)-(2). In many textbooks, $V(K)$ is implicitly assumed to be of the form $C^s(K)$ for some integer $s \ge 0$.
+At this point, it may seem more appropriate to define a finite element as a quadruplet $\{K, P, \Sigma, V(K)\}$ where the triplet $\{K, P, \Sigma\}$ complies with Definition~\ref{def:finiteelements} and $V(K)$ satisfies properties (1)-(2). However, for the sake of simplicity, we hereafter employ the well-established triplet-based definition, and always implicitly assume that there exists a normed vector space $V(K)$ satisfying properties (1)-(2). In many textbooks, $V(K)$ is implicitly assumed to be of the form $C^s(K)$ for some integer $s \ge 0$.
 \subsection{Finite elements in higher dimensions}
 We now extend the above definitions to the higher-dimensional setting, by introducing simplicial and tensor product finite elements.
 \subsubsection{Simplicial Lagrange finite elements}
@@ -1581,7 +1583,7 @@ Note the inclusions $\mathbb{P}_k \subset \mathbb{Q}_k \subset \mathbb{P}_{kd}$.
     $$ \left(\frac{i_1}{k}, \dots, \frac{i_d}{k}\right), \quad 0 \le i_1, \dots, i_d \le k. $$
     Let $\Sigma = \{\sigma_1, \dots, \sigma_{n_{sh}}\}$ be the linear forms such that $\sigma_i(p) = p(a_i)$, $1 \le i \le n_{sh}$. Then, $\{K, P, \Sigma\}$ is a Lagrange finite element.
 \end{lemma}
-For $1 \le i \le d$, set $\xi_{i,l} = c_i + \frac{l}{k}(d_i - c_i)$, $0 \le l \le k$, and let $\{\mathcal{L}_{i,0}^k, \dots, \mathcal{L}_{i,k}^k\}$ be the Lagrange polynomials in the variable $x_i$ associated with the nodes $\{\xi_{i,0}, \dots, \xi_{i,k}\}$; see Definition \ref{def:lagrangepolynomials}. Then, the local shape functions are
+For $1 \le i \le d$, set $\xi_{i,l} = c_i + \frac{l}{k}(d_i - c_i)$, $0 \le l \le k$, and let $\{\mathcal{L}_{i,0}^k, \dots, \mathcal{L}_{i,k}^k\}$ be the Lagrange polynomials in the variable $x_i$ associated with the nodes $\{\xi_{i,0}, \dots, \xi_{i,k}\}$; see Definition~\ref{def:lagrangepolynomials}. Then, the local shape functions are
 $$ \theta_{i_1 \dots i_d}(x) = \mathcal{L}_{1,i_1}^k(x_1) \dots \mathcal{L}_{d,i_d}^k(x_d), \quad 0 \le i_1, \dots, i_d \le k. $$
 
 \subsection{Finite elements in $H(\dive)$ and $H(\curl)$}
@@ -1646,7 +1648,7 @@ There is an intrinsic relationship between this structure and inf-sup conditions
 which further relates the interpolation results. 
 
 \subsection{Finite element assembly}
-Let us now go back to the Galerkin scheme associated to the Poisson equation, which consists in finding $u_h\in U_h$ such that $a(u_h, v_h) = l(v_h)$ for all $v_h\in U_h$, as introduced in \ref{eq:galerkinscheme}. We define the stiffness matrix $\ten K$ and the force vector $\vec F$ as 
+Let us now go back to the Galerkin scheme associated to the Poisson equation, which consists in finding $u_h\in U_h$ such that $a(u_h, v_h) = l(v_h)$ for all $v_h\in U_h$, as introduced in equation~\ref{eq:galerkinscheme}. We define the stiffness matrix $\ten K$ and the force vector $\vec F$ as 
 $$ K_{ij} = a(\varphi_j, \varphi_i) \quad \text{and} \quad F_i = l(\varphi_i), $$
 where $U_h = \text{span}\{\varphi_j\}_{j=1}^N$ is the discrete space spanned by its basis functions. We are solving the discrete system arising from the finite element method, which takes the form of a linear system
 $$ \ten K \vec{\alpha} = \vec{F}, $$

--- a/main.tex
+++ b/main.tex
@@ -1166,13 +1166,13 @@ Instead of discretizing the differential operator, as one would do in the case o
 \subsection{Galerkin schemes}
 Consider thus an abstract differential problem given by finding $u$ in $V$ such that
     $$ a(u, v) = L(v) \qquad \forall v \in V, $$
-such that the hypotheses of Lax-Milgram hold. In this case, we can consider a discrete space $V_h$ that approximates $V$, and thus define the following discrete problem: 
+such that the hypotheses of Lax-Milgram hold. In this case, we can consider a discrete space $V_h$ that approximates $V$, and define a Galerkin scheme as the following discrete problem: find $u_h \in V_h$ such that 
     \begin{equation*}\label{eq:galerkinscheme}
     a(u_h, v_h) = L(v_h) \qquad \forall v_h \in V_h.
     \end{equation*}
-The most notable aspect of Lax-Milgram is that all of its hypotheses hold also in $V_h$, which implies that the discrete problem is also invertible, and the \emph{a priori} estimate holds as well. The natural question is whether the discrete solution $u_h$ converges to the continuous solution $u$, which is studied through the \emph{error equation}. This is computed by setting the continuous test function $V$ as $V_h$ and then subtracting both problems: 
+The most notable aspect of Lax-Milgram is that all of its hypotheses hold also in $V_h$, which implies that the Falerkin scheme is also invertible, and the \emph{a priori} estimate holds as well. The natural question is whether the discrete solution $u_h$ converges to the continuous solution $u$, which is studied through the \emph{error equation}. This is computed by setting the continuous test function $V$ as $V_h$ and then subtracting both problems: 
     $$ a(e_h, v_h) = 0 \qquad \forall v_h \in V_h, $$
-where $e_h = u - h_h$.  This property is known as the \emph{Galerkin orthogonality}, and it can be used to compute the error estimate by considering an arbitrary function $z_h$ in $V_h$:
+where $e_h = u - u_h$.  This property is known as the \emph{Galerkin orthogonality}, and it can be used to compute the error estimate by considering an arbitrary function $z_h$ in $V_h$:
     $$ \begin{aligned}
         \alpha \| e_h \|_V^2 &\leq a(e_h, e_h) && \\ 
                              &= a(e_h, u - z_h) && \text{(Galerkin orth.)} \\
@@ -1250,7 +1250,7 @@ we can prove that this problem is well-posed provided that
 $$\frac{(1+\theta)^2 c_T}{\gamma_0}\leq 1.$$
 Moreover, this method is convergent in the $H^1$ norm for large enough $\gamma_0$. In the case that we expect more regularity, for $u\in H^s(\Omega)$ with $3/2<s<1+k$ (where $k$ is the degree of the polynomial approximation space), we get
 $$\|u-u_h\| + \|\nabla u\cdot \vec n - \nabla u_h\cdot \vec n\|_{-1/2,\partial\Omega} \leq Ch^s\|u\|_{s,\Omega}.$$
-Remarkably, and in contrast to the penalty method, the constant $C>0$ does not depend on $\gamma_00$ provided that it is large enough, but does depend on the regularity of the mesh and on the polynomial order $k$. As expected, the value of $\gamma_0$ influences the condition number of the global stiffness matrix associated to the left hand side of this problem, and thus it must not be taken too large, but the impact of the value of $\gamma_0$ on the approximation of the Dirichlet boundary condition is much smaller than in the penalty method. 
+Remarkably, and in contrast to the penalty method, the constant $C>0$ does not depend on $\gamma_0$ provided that it is large enough, but does depend on the regularity of the mesh and on the polynomial order $k$. As expected, the value of $\gamma_0$ influences the condition number of the global stiffness matrix associated to the left hand side of this problem, and thus it must not be taken too large, but the impact of the value of $\gamma_0$ on the approximation of the Dirichlet boundary condition is much smaller than in the penalty method. 
 \end{itemize}
 
 In practice, the penalty method is much simpler to understand and to implement, but its accuracy in some specific problems may not always be satisfactory. The Nitsche method is still simple to implement, and it constitutes a better alternative to the penalty method, where one has to tune only one numerical parameter. There exist more variants to these methods, such as the penalty-free Nitsche method and methods with Lagrange multipliers. The interested reader is referred to \cite{Chouly2024} for more details.
@@ -1647,68 +1647,95 @@ There is an intrinsic relationship between this structure and inf-sup conditions
     $$ \vec r_h \grad = \grad \pi_h, $$
 which further relates the interpolation results. 
 
-\subsection{Finite element assembly}
-Let us now go back to the Galerkin scheme associated to the Poisson equation, which consists in finding $u_h\in U_h$ such that $a(u_h, v_h) = l(v_h)$ for all $v_h\in U_h$, as introduced in equation~\ref{eq:galerkinscheme}. We define the stiffness matrix $\ten K$ and the force vector $\vec F$ as 
-$$ K_{ij} = a(\varphi_j, \varphi_i) \quad \text{and} \quad F_i = l(\varphi_i), $$
-where $U_h = \text{span}\{\varphi_j\}_{j=1}^N$ is the discrete space spanned by its basis functions. We are solving the discrete system arising from the finite element method, which takes the form of a linear system
-$$ \ten K \vec{\alpha} = \vec{F}, $$
-where $\vec{\alpha} \in \mathbb{R}^N$ is the vector of unknown coefficients for the basis functions. 
+\subsection{Implementation}
+% 8.1.2 Ern & Guermond
+% C21-23 Federico
+Let us now illustrate how to efficiently approximate the solution a boundary value problem using the finite element method. Given $\Omega\subset \R^d$ with boundary $\partial \Omega = \partial\Omega_D \cup \partial\Omega_N \subset \R^{d-1}$, we define its mesh $\mathcal{T}_h = \{\Omega^e\}_{e=1}^{N_{el}}$ with $N_{el}$ elements, and abusing the notation we write the mesh of the boundary $\partial\Omega$ as 
+$$\partial\mathcal{T}_h = \partial\mathcal{T}_h^D \cup\partial\mathcal{T}_h^N = \{\partial\Omega^e_D\}_{e=1}^{N_{el}^D} \cup \{\partial\Omega^e_N\}_{e=1}^{N_{el}^N}.$$
+Let $U$ be a Banach space of functions defined on $\Omega$. Consider the Poisson problem with mixed Dirichlet and Neumann boundary conditions, which consists in finding $u\in U$ such that
+$$
+\begin{cases}
+    -\Delta u = f & \text{in } \Omega, \\
+    u = g_D & \text{on } \partial\Omega_D, \\
+    \nabla u \cdot n = g_N & \text{on } \partial\Omega_N,
+\end{cases}
+$$
+where $\partial\Omega_D$ and $\partial\Omega_N$ are the non-overlapping Dirichlet and Neumann parts of the boundary. The discrete space $U_h$ associated to $U$ can be constructed from any of the finite element approximation spaces defined above, which is often chosen as a $U$-conforming space, and equipping it with appropriate boundary conditions. To this end, choose for instance $P_h^k$ as our approximation space. We apply a lifting to account for the (possibly) nonhomogeneous Dirichlet condition $u=g_D$ on $\partial\Omega_D$, and thus the suitable approximation space is
+$$U_h = P_h^k \cap U = \{v_h\in P_h^k: v_h = 0 \;\ton \partial\Omega_D\}.$$
+With this, the Galerkin scheme introduced in equation~\ref{eq:galerkinscheme} applied to our boundary value problem consists in finding $u_h \in U_h$ such that 
+$$ a_h(u_h, v_h) = l_h(v_h) \qquad \forall v_h \in U_h, $$
+where $a_h$ and $l_h$ are the discrete approximations of the bilinear form $a(u,v)=(\nabla u, \nabla v)$ and the linear form $l(v) = (f,v) + (g_N, v)_{\partial\Omega_N}$. These approximations are naturally defined by splitting the integrals into its discrete elements, that is, 
 
-\subsubsection{Naive computation and sparsity}
-Directly computing $K_{ij} = a(\varphi_j, \varphi_i)$ by integrating over the entire domain $\Omega$ for all pairs $(i,j)$ is computationally inefficient. This is because the basis functions $\varphi_j$ in finite element methods are typically chosen to have compact support, meaning $\varphi_j(x)$ is non-zero only on a small part of the domain. For basis functions associated with nodes or features of a mesh, the supports of $\varphi_i$ and $\varphi_j$ only overlap for indices $i$ and $j$ corresponding to nearby nodes or elements. Consequently, the integral $a(\varphi_j, \varphi_i) = \int_\Omega \nabla \varphi_j \cdot \nabla \varphi_i \, dx$ is zero whenever the supports of $\varphi_i$ and $\varphi_j$ do not overlap significantly. This results in the stiffness matrix $\ten K$ being sparse, i.e. most of its entries are zero. A naive computation method involving nested loops over all global indices $i$ and $j$ would spend a large amount of time computing these zero entries. 
+$$ a_h(u,v) = \sum_{e=1}^{N_{el}} \int_{\Omega^e} \nabla u \cdot \nabla v \, dx \qquad l(v) = \sum_{e=1}^{N_{el}} \int_{\Omega^e} f v \, dx + \sum_{e \in \mathcal{T}_h^N} \int_{\partial\Omega_N^e} g_N v \, dS. $$
+Since $U_h$ is finite-dimensional, we can expand $u_h$ through the basis functions $\{\varphi_i\}$ as 
+$$u_h = \sum_{i=1}^N \alpha_i \varphi_i,$$ 
+where the coordinate vector $\vec\alpha = (\alpha_1, \dots, \alpha_N)^T$ is to be determined. Since the Galerkin scheme is valid for all $v_h \in U_h$, we can choose $v_h = \varphi_i$ for $i=1,\dots,N_{el}$. For every $i=1,\dots,N_{el}$ we have
+\begin{align*}
+    a_h(u_h, \varphi_i) &= a_h(\sum_{j=1}^{N_{el}}\alpha_j\varphi_j, \varphi_i)\\
+    &= \sum_{j=1}^{N_{el}} \alpha_j a_h(\varphi_j, \varphi_i)\\
+    &= l_h(\varphi_i),
+\end{align*}
+and thus we obtain the linear system of equations 
+$$\ten K \vec \alpha = \vec F,$$
+where we have defined the \textit{stiffness matrix} $\ten K$ and the \textit{force vector} $\vec F$ as
+$$ K_{ij} = a_h(\varphi_j, \varphi_i) \quad \text{and} \quad F_i = l_h(\varphi_i). $$
 
-\paragraph{Assembly from element contributions}
-A far more efficient approach leverages the fact that the integral $a(v,w)$ and $l(v)$ can be broken down into a sum of integrals over each element $\Omega^e$ of the mesh $\mathcal{T}_h = \{\Omega^e\}_{e=1}^{N_{el}}$:
-$$ a(v,w) = \sum_{e=1}^{N_{el}} \int_{\Omega^e} \nabla v \cdot \nabla w \, dx \qquad l(v) = \sum_{e=1}^{N_{el}} \int_{\Omega^e} f v \, dx + \sum_{e \in \mathcal{T}_h^N} \int_{\partial\Omega_N^e} g_N v \, dS, $$
-where $\mathcal{T}_h^N$ is the set of elements with a Neumann boundary segment on $\partial\Omega_N$.
-The global stiffness matrix $\ten K$ and force vector $\vec{F}$ can thus be assembled by summing contributions from each element:
-$$ \ten K = \sum_{e=1}^{N_{el}} \ten K^e \qquad \vec{F} = \sum_{e=1}^{N_{el}} \vec{F}^e. $$
-Here, $K^e$ is the element stiffness matrix and $\vec{F}^e$ is the element force vector (or more precisely, their contribution to the global matrix/vector). The entries of $\ten K^e$ and $\vec{F}^e$ are computed based on the basis functions restricted to the element $\Omega^e$.
+Here, we note that computing $K_{ij} = a(\varphi_j, \varphi_i)$ by integrating over the entire domain $\Omega$ for all pairs $(i,j)$ is computationally inefficient, because the basis functions $\varphi_j$ in finite element methods are typically chosen to have compact support, meaning $\varphi_j(x)$ is non-zero only on a small part of the domain. For basis functions associated with nodes of a mesh, the supports of $\varphi_i$ and $\varphi_j$ only overlap for indices $i$ and $j$ corresponding to neighboring nodes or elements, and thus $a(\varphi_j, \varphi_i)$ will be nonzero only for those neighboring $(i,j)$ pairs. This results in the stiffness matrix $\ten K$ being sparse, i.e. most of its entries are zero, and thus a naïve computation method involving nested loops over all global indices $i$ and $j$ would spend an unnecessary amount of time computing zero entries. 
 
-\paragraph{Local element matrices and vectors}
-Within each element $\Omega^e$, the global basis functions $\varphi_j$ that are non-zero on $\Omega^e$ are those associated with the nodes of that element. Let $n_v$ be the number of vertices (or nodes) per element (e.g., $n_v=2$ for 1D segments, $n_v=3$ for 2D triangles, $n_v=4$ for 2D quadrilaterals or 3D tetrahedra/hexahedra). We define local shape functions $\phi_a^e$, $a=1, \dots, n_v$, which are the restrictions of the global basis functions to the element $\Omega^e$, re-indexed locally from 1 to $n_v$.
-The element stiffness matrix $\ten k^e$ (size $n_v \times n_v$) and element force vector $\vec f^e$ (size $n_v$) are defined by integrals over the element $\Omega^e$ using these local shape functions:
+To put this into practice, let $(\Omega, V_h, \Sigma$ be a finite element. Within each element $\Omega^e$, the global basis functions $\varphi_j$ of $V_h$ that are non-zero on $\Omega^e$ are those associated with the nodes of that element. Let $n_{dof}$ number of degrees of freedom (nodes) of the finite element. We define local shape functions $\phi_a^e$, $a=1, \dots, n_{dof}$, which are the restrictions of the global basis functions to the element $\Omega^e$, re-indexed locally from 1 to $n_{dof}$. We define the \textit{element stiffness matrix} $\ten k^e \in \R^{n_{dof}\times n_{dof}}$ and \textit{element force vector} $\vec f^e \in \R^{n_{dof}}$ as integrals over $\Omega^e$ using these local shape functions, i.e.
 $$ k_{ab}^e = \int_{\Omega^e} \nabla \phi_b^e \cdot \nabla \phi_a^e \, dx \quad \text{and} \quad f_a^e = \int_{\Omega^e} f \phi_a^e \, dx. $$
 If the element $\Omega^e$ has a Neumann boundary segment on $\partial \Omega_N$, there is also a local Neumann boundary force vector $f_{N,a}^e$:
 $$ f_{N,a}^e = \int_{\partial\Omega_N^e} g_N \phi_a^e \, dS. $$
-\paragraph{The assembly algorithm}
-The process of adding the contributions from the local element matrices and vectors into the global system, known as assembly, requires precisely mapping the local effects within each element to their corresponding locations in the global stiffness matrix $\ten K$ and force vector $\vec{F}$. This mapping accounts for both the topological connectivity of the mesh elements and the boundary conditions applied to the domain. We use several arrays to manage this mapping. The element node matrix (IEN) is a connectivity array where $IEN(a, e)$ provides the global node index corresponding to the local node $a$ (ranging from 1 to $n_v$) within element $e$ (ranging from 1 to $N_{el}$). The destination array (ID) then maps each global node index $i$ to its corresponding equation number or global degree of freedom (DOF) index in the assembled linear system. If global node $i$ has a prescribed boundary condition (such as a Dirichlet value), $ID(i)$ is typically set to 0 or a negative value to indicate that this node does not correspond to an unknown degree of freedom in the system. The location matrix (LM) can be viewed as a combined mapping that directly provides the global DOF index for a local node $a$ of element $e$. As shown in the notes, the LM matrix, which has dimensions $n_v \times N_{el}$, can be conceptually defined such that $LM(a, e) = ID(IEN(a, e))$. In simpler cases, like the 1D mesh example shown in the notes with $N_{el}=N$ elements and $n_v=2$ nodes per element, where global node indices run from 1 to $N_{el}+1=N+1$ and elements connect sequentially, the LM might be presented directly as:
-$$ LM = \begin{bmatrix}
-1 & 2 & 3 & \cdots & N_{el} \\
-2 & 3 & 4 & \cdots & N_{el}+1
-\end{bmatrix} $$
-In this specific 1D illustration, $LM(1, e) = e$ maps local node 1 of element $e$ to global node $e$, and $LM(2, e) = e+1$ maps local node 2 of element $e$ to global node $e+1$. The full mapping to degrees of freedom in the presence of general boundary conditions is captured by the $ID(IEN(a,e))$ relation, which is the index ultimately used to locate the correct row and column in the global system during assembly. The pseudocode below details the assembly algorithm using this mapping to add the contributions from the element matrices $\ten k^e$ and vectors $\vec f^e$ to the global system $\ten K$ and $\vec F$.
+The assembly process of adding the contributions from the local element matrices and vectors into the global system requires precisely mapping the local effects within each element to their corresponding locations in the global stiffness matrix $\ten K$ and force vector $\vec{F}$. This mapping accounts for both the topological connectivity of the mesh elements and the boundary conditions applied to the domain. We use several arrays to manage this mapping.
+\begin{enumerate}
+    \item The element node matrix $IEN\in \mathbb{Z}^{n_{el}\times n_{dof}}$ is a connectivity array with terms $IEN[e, a]$, which provides the global node index corresponding to the local node $a$ (ranging from 1 to $n_{dof}$) within element $e$ (ranging from 1 to $N_{el}$). Explicitly, if we have three elements in 1D, whose global node indexes are $(0,1)$, $(1,2)$ and $(2,3)$, respectively, then the $IEN$ matrix is 
+    $$ IEN = \begin{bmatrix}
+    0 & 1 \\
+    1 & 2 \\
+    2 & 3
+    \end{bmatrix} $$
+    \item The destination array $ID\in \mathbb{Z}^{n_{nodes}}$ maps each global node index $i$ to its corresponding equation number or global degree of freedom index in the assembled linear system. If global node $i$ has a prescribed boundary condition (such as a Dirichlet value), $ID(i)$ is typically set to 0 or a negative value to indicate that this node does not correspond to an unknown degree of freedom in the system. For example, if we have $n_{nodes}=4$ nodes in a 1D mesh, where where nodes $1$ and $3$ have Dirichlet boundary conditions, the $ID$ array might look like:
+    $$ ID = \begin{bmatrix}
+    0 \\
+    1 \\
+    0 \\
+    2
+    \end{bmatrix} $$
+    where the nonzero entries correspond to free nodes.
+    \item The location matrix $LM\in \mathbb{Z}^{n_{el}\times n_{dof}}$ corresponds to the composite local-to-global mapping, where for a given element $e$ and a local node $a$, $LM[e,a]$ corresponds to the global degree of freedom index. This allows us to write the important relation 
+    $$LM[e,a] = ID[IEN[e,a]].$$
+\end{enumerate}
+    The full mapping to degrees of freedom in the presence of general boundary conditions is captured by the $ID[IEN[e,a]]$ relation, which is the index ultimately used to locate the correct row and column in the global system during assembly. The pseudocode below details the assembly algorithm using this mapping to add the contributions from the element matrices $\ten k^e$ and vectors $\vec f^e$ to the global system $\ten K$ and $\vec F$.
 \begin{algorithmic}[1]
     \State Initialize global stiffness matrix $\ten K$ and force vector $\vec{F}$ to zero.
     \For{each element $e = 1, \dots, N_{el}$}
-        \State Compute element stiffness matrix $k^e$ ($n_v \times n_v$) and force vector $f^e$ ($n_v \times 1$).
-        \For{each local node $a = 1, \dots, n_v$}
-            \State $i = LM(a, e)$.
-            \For{each local node $b = 1, \dots, n_v$}
-                \State $j = LM(b, e)$.
-                \If{$i \neq 0$ and $j \neq 0$}
+        \State Compute element stiffness matrix $\ten k^e\in\R^{n_{dof} \times n_{dof}}$ and force vector $\vec f^e\in\R^{n_{dof}}$.
+        \For{each local node $a = 1, \dots, n_{dof}$}
+            \State $i = LM[e,a]$.
+            \For{each local node $b = 1, \dots, n_{dof}$}
+                \State $j = LM[e,b]$.
+                \If{$i \neq 0$ and $j \neq 0$} \Comment{Free nodes}
                     \State $K_{i,j} \gets K_{i,j} + k^e_{ab}$.
                 \EndIf
-                \If{$i \neq 0$ and $j == 0$}
-                    \State $F_i \gets F_i - g_L  k^e_{ab}$.
+                \If{$j$-th node is on the Dirichlet boundary $\partial\mathcal{T}_h^D$} \Comment{Dirichlet nodes}
+                    \State $F_i \gets F_i - g_D k^e_{ab}$.
                 \EndIf
             \EndFor
-            \If{$i \neq 0$}
+            \If{$i \neq 0$} \Comment{Non-Dirichlet nodes}
                 \State $F_i \gets F_i + f^e_a$.
             \EndIf
-            \If{$i == N$}
-                \State $F_i \gets F_i + q_R$.
+            \If{$i$-th node is on the Neumann boundary $\partial\mathcal{T}_h^N$} \Comment{Neumann nodes}
+                \State $F_i \gets F_i + f^e_{N,a}$.
             \EndIf
         \EndFor
         \EndFor
     \end{algorithmic}
-This element-by-element assembly ensures that only non-zero contributions are added to the global system, efficiently building the sparse matrix $\ten K$.
 
 \paragraph{Efficient computation of element integrals via the master element}
 Computing the integrals for $\ten k^e$ and $\vec f^e$ directly on each physical element $\Omega^e$ can be complicated due to the varied shapes and sizes of elements in a mesh. The standard technique is to map each physical element $\Omega^e$ to a single, simple reference element, called the master element $\hat{\Omega}$. This master element is always the same (e.g., $[-1,1]$ for 1D segments, a standard triangle or square for 2D, etc.).
 
 Let $\vec{x} = \vec{x}(\vec{\xi})$ be the transformation mapping a point $\vec{\xi}$ in the master element $\hat{\Omega}$ to a point $\vec{x}$ in the physical element $\Omega^e$. This transformation is typically defined using the shape functions:
-$$ \vec{x}(\vec{\xi}) = \sum_{a=1}^{n_v} \vec{x}_a^e \hat{\phi}_a(\vec{\xi}), $$
+$$ \vec{x}(\vec{\xi}) = \sum_{a=1}^{n_{dofs}} \vec{x}_a^e \hat{\phi}_a(\vec{\xi}), $$
 where $\vec{x}_a^e$ are the physical coordinates of the nodes of element $e$, and $\hat{\phi}_a(\vec{\xi})$ are the shape functions defined on the master element. The local shape functions on the physical element are related to the master element shape functions by $\phi_a^e(\vec{x}) = \hat{\phi}_a(\vec{\xi}(\vec{x}))$, where $\vec{\xi}(\vec{x})$ is the inverse transformation.
 
 The change of variables formula for integrals states that
@@ -1720,16 +1747,19 @@ Using these, the element integrals become integrals over the master element:
 $$ k_{ab}^e = \int_{\hat{\Omega}} (J^{-T} \nabla_{\vec{\xi}} \hat{\phi}_b) \cdot (J^{-T} \nabla_{\vec{\xi}} \hat{\phi}_a) |\det J| \, d\hat{\Omega}, $$
 $$ f_a^e = \int_{\hat{\Omega}} f(\vec{x}(\vec{\xi})) \hat{\phi}_a(\vec{\xi}) |\det J| \, d\hat{\Omega}, $$
 $$ f_{N,a}^e = \int_{\partial\hat{\Omega}_N} g_N(\vec{x}(\vec{\xi})) \hat{\phi}_a(\vec{\xi}) |\det J_{\partial}| \, d\hat{\Gamma}, $$
-where $J_\partial$ is the Jacobian of the transformation on the boundary segment. These integrals over the master element can be computed efficiently using numerical integration rules (quadrature). The shape functions $\hat{\phi}_a$ and their gradients on the master element, and the Jacobian and its determinant, only need to be evaluated at the fixed quadrature points on $\hat{\Omega}$.
+where $J_\partial$ is the Jacobian of the transformation on the boundary segment. These integrals over the master element can be computed efficiently using numerical integration rules, known as \textit{quadratures}. The shape functions $\hat{\phi}_a$ and their gradients on the master element, and the Jacobian and its determinant, only need to be evaluated at the fixed quadrature points on $\hat{\Omega}$.
 
-\paragraph{Element types and shape functions}
-The definition of the shape functions $\hat{\phi}_a$ and the specific master element geometry depend on the type of finite element used.
-\begin{itemize}
-    \item \textbf{Simplicial elements:} These are line segments in 1D, triangles in 2D, and tetrahedra in 3D. For these elements, especially linear ones, the shape functions are often closely related to barycentric coordinates. Barycentric coordinates $\{\lambda_a\}_{a=1}^{n_v}$ on a simplex satisfy $\sum_{a=1}^{n_v} \lambda_a(\vec{x}) = 1$ and $\lambda_a(\vec{x}_b^e) = \delta_{ab}$.
-    \item \textbf{Tensor product elements:} These are constructed from products of 1D elements, such as quadrilaterals in 2D (bilinear Q1, biquadratic Q2, etc.) and hexahedra in 3D. The shape functions are tensor products of the 1D shape functions. For example, on the reference square $[-1,1]^2$, the bilinear (Q1) shape functions are products of 1D linear functions: $\hat{\phi}_a(\xi, \eta) = \hat{\phi}_{a_\xi}(\xi) \hat{\phi}_{a_\eta}(\eta)$.
-    \item \textbf{Other element types:} Meshes can also include other element types like prisms and pyramids, particularly in 3D as transition elements between tetrahedral and hexahedral regions. The shape functions for these elements are more complex.
-\end{itemize}
-For higher-order elements (using polynomials of degree $k > 1$), the shape functions are polynomials of degree $k$ on the element. Their definition and the choice of nodes depend on the element type. The transformation to the master element and the assembly process remain analogous.
+\example{In 2D, we can define a triangular (simplicial) element with vertices $\vec{x}_0^e$, $\vec{x}_1^e$, and $\vec{x}_2^e$. The master element is the reference triangle with vertices $(0,0)$, $(1,0)$, and $(0,1)$. In this setting the local shape functions are given by 
+\begin{align*}
+\hat{\phi}_0(\xi_1, \xi_2) &= \xi_1,\\
+\hat{\phi}_1(\xi_1, \xi_2) &= \xi_2, \\
+\hat{\phi}_2(\xi_1, \xi_2) &=  1 - \xi_1 - \xi_2.
+\end{align*}
+Thus, the mapping from the master element with coordinates $\vec\xi = (\xi_1,\xi_2)$ to the physical element with coordinates $\vec x = (x_1, x_2)$ is given by
+$$ \vec{x}(\xi_1, \xi_2) =  \vec{x}_0^e\xi_1  + \vec{x}_1^e \xi_2 + \vec{x}_2^e (1-\xi_1-\xi_2). $$
+}
+\subsubsection{Nonhomogeneous Dirichlet boundary conditions}
+% 8.4 Ern & Guermond
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \section{Beyond ellipticity}\label{section:beyond-ellipticity}

--- a/main.tex
+++ b/main.tex
@@ -1760,6 +1760,35 @@ $$ \vec{x}(\xi_1, \xi_2) =  \vec{x}_0^e\xi_1  + \vec{x}_1^e \xi_2 + \vec{x}_2^e 
 }
 \subsubsection{Nonhomogeneous Dirichlet boundary conditions}
 % 8.4 Ern & Guermond
+There exist several approaches to treat the implementation of nonhomogeneous Dirichlet boundary conditions, which we introduce from \cite{ern2004theory}. Assume that there exist $N_D$ Dirichlet nodes in the mesh, and thus $N_{free} = N_{el} - N_D$ free nodes.
+\begin{itemize}
+    \item \underline{Eliminating the Dirichlet nodes}: a straightforward method is to reorder the global degrees of freedom so that the first $N_D$ rows of the system correspond to the Dirichlet nodes, and the remaining $N_{free}$ rows correspond to the free nodes. Introduce the notation $\vec x = (\hat{\vec x},\tilde{\vec x})$ where $\hat{\vec x} = (x_1,\dots,x_{N_D})^\top$ and $\tilde{\vec x} = (x_{N_D + 1},\dots,x_{N_el})$ are the Dirichlet and non-Dirichlet parts of the vector $\vec x$. This induces a block problem 
+    $$
+        \left[
+    \begin{array}{cc}
+    \ten I & \vec{0} \\
+    \ten B & \ten{\tilde{K}}
+    \end{array}
+    \right]
+    \begin{bmatrix}
+    \hat{\vec\alpha} \\
+    \tilde{\vec\alpha}
+    \end{bmatrix}
+    =
+    \begin{bmatrix}
+    \hat{\vec F} \\
+    \tilde{\vec F}
+    \end{bmatrix},
+    $$
+    where $B_{ij} = a_h(\varphi_j, \varphi_i)$ for $i=N_D+1,\dots,N_{el}$ and $j=1,\dots,N_{D}$ and $\tilde{K}_{ij} = a_h(\varphi_j, \varphi_i)$ for $i,j=N_D+1,\dots,N_{el}$. Here, it is clear that the subsystem associated to the Dirichlet nodes is trivial, i.e. $\hat{\vec \alpha} = \hat{\vec F}$, and thus we can eliminate the Dirichlet nodes from the system. The resulting system is given by 
+    $$\ten{\tilde{K}} \tilde{\vec\alpha} = \tilde{\vec F} - \ten B \hat{\vec F},$$
+    which implies that we need to assemble now two matrices, with sparsity profiles that may not be inherited from $\ten K$. This is exactly equivalent to performing a lifting on the original system, as seen in Remark 8.17 in \cite{ern2004theory}.
+    \item \underline{Keeping the Dirichlet nodes}: instead of eliminating the Dirichlet nodes, we can keep them in the system and assemble as usual, which leads to the stiffness matrix and force vector associated to the Neumann problem. After assembling, we correct the rows of $\ten K$ corresponding to the $N_D$ Dirichlet nodes, by setting them equal to zero, except the diagonal which is set to 1. Similarly, we set the entries of $\vec F$ corresponding to the Dirichlet nodes equal to the prescribed values. Although the resulting system has more degrees of freedom, by using an appropriate iterative solver (such as a Krylov subspace method), the Dirichlet data will be exactly satisfied in the solution for every iteration. 
+    \item \underline{The penalty method}: as we studied previously in the context of non-conforming spaces, one can add a penalty term to the Dirichlet nodes to enforce them approximately. First, one assembles $\ten K$ and $\vec F$ as usual, which corresponds to the Neumann problem system. Then, in every row corresponding to a Dirichlet node, one adds the penalty term 
+    $$\varepsilon^{-1}\alpha_i = \varepsilon^{-1}g_{D,i}$$
+    where $g_{D,i}$ is the Dirichlet data at node $i$ and $\varepsilon$ is a small positive parameter. In contrast to the previous two methods, this method does not ensure that the Dirichlet data is satisfied exactly, but it allows one to inherit the possible symmetry of the original stiffness matrix $\ten K$, which is a very useful property for iterative solvers. The penalty method is also particularly useful when the Dirichlet data is not smooth, as it allows one to control the convergence of the solution to the Dirichlet data by adjusting the penalty parameter $\varepsilon$.
+\end{itemize}
+
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \section{Beyond ellipticity}\label{section:beyond-ellipticity}


### PR DESCRIPTION
Hola Nico, 

En esta PR rehice la sección de implementación de elementos finitos, que sería la última subsección del capítulo de elementos finitos. Conecté acá con los esquemas de Galerkin que se definieron antes (asumí U_h = V_h, no consideré el caso Bubnov-Galerkin) para la ecuación de Poisson con condiciones de borde mixtas. También corregí las cosas de la PR anterior, lo único que no cambié fue lo de "uplet", ya que sale así mismo escrito en el Ern & Guermond.