### PR TITLE
Continuum mechanics 2

### DIFF
--- a/main.tex
+++ b/main.tex
@@ -3381,7 +3381,7 @@ The extension of this rule to higher dimensions is known as the Reynolds transpo
 
 \subsection{Mechanics and stress}
 So far, we have discussed how to describe finite strain via deformation metrics, which stem from the deformation map $\vvarphi$. Here, we introduced the deformation gradient tensor $\tenF$, from which we defined the Cauchy-Green right deformation tensor $\ten C$ and the Euler-Lagrange deformation tensor $\ten E$. We now have to connect these deformations to the actual forces and tensions that exist in a body. To this end, we need to define traction vector fields and the stress tensors.
-\begin{definition}[Traction vectors and stress tensors]
+\begin{definition}[Traction vectors]
     Let $d\vec f$ be the internal force acting on a 2D differential element $da$ in $\vec x$ at time $t$. We define the \textit{spatial traction field} $\vec t=\vec t(\vec n, \vec x, t)$ as 
     \begin{equation*}
         d\vec f(\vec x, t) =: \vec t(\vec n, \vec x, t) da.
@@ -3390,11 +3390,53 @@ So far, we have discussed how to describe finite strain via deformation metrics,
     \begin{equation*}
         d\vec f\circ\vvarphi = \vec T(\vec N, \vec X, t) dA,
     \end{equation*}
-    where we also recall the Nanson-Piola formula $\vec n da = J\tenF^{-\top} \vec N dA$. Cauchy's stress theorem states that there exists a unique second-order tensor $\ten \sigma$, called the \text{Cauchy stress tensor}, such that 
-    \begin{equation*}
-        \vec t(\vec x, \vec n, t) = \ten\sigma(\vec x, t)\vec n,
-    \end{equation*}
-    and also there exists a unique second-order tensor $\ten P$, called the \textit{first Piola-Kirchhoff stress tensor}, such that
+    where we also recall the Nanson-Piola formula $\vec n da = J\tenF^{-\top} \vec N dA$. 
+\end{definition}
+To relate traction vectors to deformation metrics, we need to define stress tensors. We do this by invoking a theorem that ensures the uniqueness of such a tensor in the spatial frame, which we can later pull back to the material frame. This theorem assumes the conservation of linear and angular momenta, which we will discuss later on in this chapter. For now, linear momentum conservation means that body forces, traction forces and inertia are in equilibrium.
+\begin{theorem}[Cauchy's stress theorem]
+    At any instant $t$, let $\vec f\in C(\Omega_t)^3$ be the body force and $\vec t(\vec x, \vec n)$ a traction field that is continuously differentiable with respect to $\vec n$ for any fixed $\vec x\in\Omega_t$, and also with respect to $\vec x$ for fixed $\vec n$. If linear and angular momenta are conserved, then there exists a unique second-order tensor $\ten \sigma(\vec x, t)$ such that
+    \begin{align*}
+        \vec t(\vec x, t, \vec n) &= \ten\sigma(\vec x, t)\vec n,\qquad \forall\vec x\in\Omega_t, \forall\vec n\\
+        \ten\sigma(\vec x, t) &= \ten\sigma(\vec x, t)^\top,\qquad \forall\vec x\in\Omega_t.
+    \end{align*}
+    Here, $\ten \sigma$ is called the \textit{Cauchy stress tensor}.
+    \begin{proof}
+        We define a tetrahedron $T$ with three orthogonal faces with normal vectors $\vec n_1 = -\vec e_1$, $\vec n_2 = -\vec e_2$ and $\vec n_3 = -\vec e_3$, and the fourth face $F$ with normal vector $\vec n$. Let $F_i$ be the face of $T$ with normal vector $-\vec e_i$. In this setting, it holds that $|F_i|=n_i|F|$. The conservation of linear momentum here reads
+        \begin{equation*}
+            \int_T \vec f(\vec x, t)dv + \int_{\partial T}\vec t(\vec x, t, \vec n)ds = \int_T \rho\frac{D\vec v}{Dt}dv,
+        \end{equation*}
+        and for each component of the traction we get 
+        \begin{align*}
+            \int_{\partial T} t_i(\vec x, t, \vec n) ds &= \sum_{j=1}^3 \int_{F_j} t_i(\vec x, t, -\vec e_j) ds + \int_F t_i(\vec x, t, \vec n) ds\\
+            &= \sum_{j=1}^3 t_i(\vec x^*_j,t,-\vec e_j)|F_j| + t_i(\vec x^*, t, \vec n)|F|\tag{mean value theorem}\\
+            &= \left(\sum_{j=1}^{3}t_i(\vec x_j^*,t,-\vec e_j)n_j + t_i(\vec x^*,t,\vec n) \right)|F|.
+        \end{align*}
+        Thus, we have 
+        \begin{equation*}
+            \left|\int_{\partial T}t_i(\vec x, t)ds\right| = \left|\int_T \left(\rho(\vec x)\frac{Dv_i(\vec x)}{Dt} - f_i(\vec x)\right)dv\right|,
+        \end{equation*}
+        and replacing with the previous equality we get 
+        \begin{equation*}
+            \left|\sum_{j=1}^{3}t_i(\vec x_j^*,t,-\vec e_j)n_j + t_i(\vec x^*,t,\vec n)\right| |F| \leq \left\|\rho\frac{Dv_i}{Dt}-f_i\right\|_\infty \int_T dv,
+        \end{equation*}
+        where $\int_T dv = C|F|^{3/2}$ is the volume of the tetrahedron for some constant $C$. Dividing by $|F|$ and taking the limit as $|F|\to 0$, we obtain
+        \begin{equation*}
+            \left|\sum_{j=1}^{3}t_i(\vec x_j^*,t,-\vec e_j)n_j + t_i(\vec x^*,t,\vec n)\right| = 0,
+        \end{equation*}
+        that is, 
+        \begin{equation*}
+            \sum_{j=1}^{3}t_i(\vec x_j^*,t,-\vec e_j)n_j = - t_i(\vec x^*,t,\vec n).
+        \end{equation*}
+        Defining tensor $\ten \sigma(\vec x, t)$ by components as 
+        \begin{equation*}
+            \sigma_{ij}(\vec x, t) := -t_i(\vec x, t, -\vec e_j),
+        \end{equation*}
+        we obtain $t_i(\vec x, t, \vec n) = \sigma_{ij}(\vec x, t)n_j$, which in vector form is simply $\vec t(\vec x, t, \vec n) = \ten\sigma(\vec x, t)\vec n$. The symmetry of $\ten\sigma$ follows from the conservation of angular momentum and is left as an exercise.
+    \end{proof}
+\end{theorem}
+The traction vector in the material frame can be subject to the same derivation, and we relate both tensors as follows.
+\begin{definition}[Piola-Kirchhoff stress tensors]
+    There exists a unique second-order tensor $\ten P$, called the \textit{first Piola-Kirchhoff stress tensor}, such that
     \begin{equation*}
         \vec T(\vec X, \vec N, t) = \ten P(\vec X, t)\vec N.
     \end{equation*}
@@ -3406,8 +3448,9 @@ So far, we have discussed how to describe finite strain via deformation metrics,
     \begin{equation*}
         \ten S := \tenF^{-1}\ten P = J\tenF^{-1}\ten\sigma\tenF^{-\top}.
     \end{equation*}
-    The tensor $\ten S$ formally corresponds to the \textit{pullback} of $\ten \sigma$, or equivalently, $\ten\sigma$ is the \textit{push-forward} of $\ten S$. % This notion is further studied in \ref{holzapfel}.
+    The tensor $\ten S$ formally corresponds to the \textit{pullback} of $\ten \sigma$, or equivalently, $\ten\sigma$ is the \textit{push-forward} of $\ten S$.
 \end{definition}
+
 \subsection{Conservation laws}
 With the above definitions and the precise technique to differentiate quantities defined as spatial integrals via the Reynolds transport theorem, we can now write down \textit{conservation laws}, which are relationships between the rates of change of quantities of interest (e.g. mass, momentum) and the factors that physically induce those rates of change. Conservation laws define the partial differential equations that will be at the core of our numerical analysis later on. These laws have spatial and material formulations, both of which can be written in integral or differential form. To pass from the integral to the differential form, we use the following theorem: 
 \begin{theorem}[Localization theorem]
@@ -3683,7 +3726,7 @@ We now study some explicit cases.
 \paragraph{Constitutive modeling of solids} 
 Assuming that $\ten S$ deppends only on the deformation $\vvarphi$, we first obtain that $\ten S$ depends on $\tenF$ due to the locality principlpe, and from the observer independence, we conclude that $\ten S$ is a function of $\ten C=\tenF^\top \tenF$ or $\ten E = \frac{1}{2}(\ten C - \ten I)$. Some examples are the linear elastic model $\ten S(\ten E) = \lambda\tr(\ten E)\ten I + 2\mu\ten E$, and the neohookean model $\ten S(\ten C) = \frac{\lambda}{2}(J^2-1)\ten C^{-1} + \mu (\ten I - \ten C^{-1})$, where $\lambda,\mu$ are called the Lamé parameters. These parameters are obtained from experiments, and are related to the Young modulus $E$ and the Poisson ratio $\nu$. Since $\tenF=\ten I + \vX \vec u$, $\ten C$ and $\ten E$ are also functions of $\vec u$, and thus $\ten S(\ten E)$ also is a function of $\vec u$, thus allowing us to rewrite the conservation of linear momentum as
 \begin{equation*}
-    \rho_0\ddot{\vec u} = \vec f_0 + \vX\cdot(\tenF(\vec u) \ten S(\ten E(\vec u))),
+    \rho_0\ddot{\vec u} = \vec f_0 + \dive(\tenF(\vec u) \ten S(\ten E(\vec u))),
 \end{equation*}
 which are called the \textit{elastodynamics equations}. These equations are nonlinear in $\vec u$, because at least $\ten E$ is not linear due to the term $(\vX\vec u)^\top (\vX\vec u)$. If we know the initial density $\rho_0(\vec X)$, the initial position $\vec u(\vec X, 0)$, the initial velocity $\dot{\vec u}(\vec X, 0)$, the forces $\vec f_0(\vec X, t)$ and boundary conditions on $\vec u$ or $\ten P\vec n$ for all times $t>0$, we can attempt to solve for $\vec u(\vec X, t)$. Moreover, if the object is stationary, the acceleration is $\ddot{\vec u}=0$, and thus the equations reduce to the \textit{elastostatics equations}
 \begin{equation*}
@@ -3695,8 +3738,8 @@ In a small-deformation regime, we checked that $\ten E \approx \ten \varepsilon 
 \end{equation*}
 which we can differentiate easily to get the explicit equations. Another way of writing $\ten S$ as a tensor field that is linear on $\ten\varepsilon$ is through a fourth-order \text{elasticity tensor} $\mathbb{C}$, which in the linear case results $\ten S(\ten\varepsilon(\vec u)) = \mathbb{C}:\ten\varepsilon(\vec u)$, resulting in the linear elastodynamics and elastostatic equations 
 \begin{align*}
-    \rho_0 \ddot{\vec u} &= \vec f_0 + \vX \cdot(\mathbb{C}:\ten\varepsilon(\vec u))\\
-    \vec 0 &= \vec f_0 + \vX \cdot(\mathbb{C}:\ten\varepsilon(\vec u)).
+    \rho_0 \ddot{\vec u} &= \vec f_0 + \dive(\mathbb{C}:\ten\varepsilon(\vec u))\\
+    \vec 0 &= \vec f_0 + \dive(\mathbb{C}:\ten\varepsilon(\vec u)).
 \end{align*}
 In the stationary case, there is no dependence on time, and thus it is not necessary to specify any initial conditions, but we do requiere boundary conditions on the displacement or the stress. Moreover, the solutions for the nonlinear $\ten S$ case may not be unique, but they are indeed unique in the linear case, where we can rewrite our problem in terms of an elliptic operator. We also note that the linear elastic model is an isotropic material model, and only depends on the two Lamé parameters $\lambda, \mu$. By contrast, linear materials with less symmetries on $\mathbb{C}$ requiere up to 21 parameters to fully describe their behavior. 
 
@@ -3789,6 +3832,87 @@ Other thermal and non-thermal fluid models are used in practice for different pu
     \frac{\partial h}{\partial t} + \vx((H+h)\vec v) = 0.
 \end{equation*}
 These equations are known as the \textit{shallow water equations}, and are used to model floodings and tsunamis.  
+
+\subsection{Analysis}
+In this section we use the PDE analysis machinery we have developed in the previous chapters to analyze the PDE systems we have derived. 
+\paragraph{Elastostatics equations} We previously derived the elastostatics equation as the steady-state version of conservation of linear momentum. Let $\Omega\subset\R^k$ with $k\in\{2,3\}$ be a bounded Lipschitz domain with boundary $\partial\Omega$. In a simple case, we can enforce a Dirichlet boundary condition $\vec u = \vec 0$ on $\partial\Omega$. Then, the problem consists of finding a function $\vec u\in (H_0^1(\Omega))^k$ such that 
+\begin{equation*}
+    \begin{cases}
+        \vec 0 &= \vec f_0 + \dive (\mathbb{C}:\ten\varepsilon(\vec u))\\
+        \vec u &= \vec 0 \text{ on } \partial\Omega,
+    \end{cases}
+\end{equation*}
+where $\mathbb{C}$ is the linear, positive definite and symmetric fourth-order elasticity tensor. This translates to 
+\begin{equation*}
+    \mathbb{C}\ten A : \ten B = \ten A : \mathbb{C}\ten B, \qquad \mathbb{C}\ten A : \ten A \geq \rho_0\|\ten A\|^2,
+\end{equation*}
+where $\rho_0>0$ is constant. Multiplying by a test function $\vec v\in (H_0^1(\Omega))^k$ we get 
+\begin{align*}
+    \int_\Omega \vec f_0\cdot\vec v dv &= \int_\Omega -\dive(\mathbb{C}:\ten\varepsilon(\vec u))\cdot\vec v dv\\
+    &= \int_\Omega \ten\varepsilon(\vec u):\mathbb{C}:\nabla\vec v dv - \int_\Omega \dive ((\mathbb{C}:\ten\varepsilon(\vec u))\vec v)dv \tag{integration by parts}\\
+    &= \int_\Omega \ten\varepsilon(\vec u):\mathbb{C}:\ten\varepsilon(\vec v) dv - \int_{\partial\Omega} (\mathbb{C}:\ten\varepsilon(\vec u))\vec v \cdot\vec n ds\tag{divergence theorem, $(\ast)$}\\
+    &= \int_\Omega \ten\varepsilon(\vec u):\mathbb{C}:\ten\varepsilon(\vec v) dv \tag{$\vec v\in(H_0^1(\Omega))^k$},
+\end{align*}
+where in $(\ast)$ we used the fact that $\varepsilon(\vec u):\mathbb{C}$ is a symmetric tensor, and thus contracting it with the antisymmetric part of $\nabla\vec v$ yields zero, thus leaving only the symmetric part of the gradient, which is precisely $\ten\varepsilon(\vec v)$. This results in the weak formulation
+\begin{equation*}
+    \underbrace{\int_\Omega \ten\varepsilon(\vec u):\mathbb{C}:\ten\varepsilon(\vec v) dv}_{b(\vec u, \vec v)} = \underbrace{\int_\Omega \vec f_0\cdot\vec v dv}_{\ell(v)}, \qquad \forall \vec v\in (H_0^1(\Omega))^k,
+\end{equation*}
+where $b$ is a bilinear form since $\ten\varepsilon$ is linear, and $\ell$ is linear. This formulation has trial and test function spaces $U=V=(H_0^1(\Omega))^k$. We can prove that $b$ is continuous through the Cauchy-Schwarz and triangle inequalities. Further, we can show that $b$ is elliptic through Korn's inequality, which states that there exists $c>0$ such that
+\begin{equation*}
+    \|\vec u\|_{H^1(\Omega)} \leq C_K\|\ten\varepsilon(\vec u)\|_{L^2(\Omega)},
+\end{equation*}
+resulting in the bound $|b(\vec u, \vec u)|\geq \rho_0/C_K^2\|\vec u\|_{H^1(\Omega)}^2$. Further, we know that $(H_0^1(\Omega))^k$ is reflexive, since $L^2(\Omega)$ is reflexive and $H_0^1(\Omega)$ is a closed subspace of $L^2(\Omega)$. Thus, all assumptions of the Lax-Milgram lemma are satisfied, and we can conclude that there exists a unique solution $\vec u\in (H_0^1(\Omega))^k$ to the weak formulation that satisfies the a priori estimate
+\begin{equation*}
+    \|\vec u\|_{H^1(\Omega)} \leq \frac{C_K^2}{\rho_0}\|\ell\|_{((H^1(\Omega))^k)^*}.
+\end{equation*}
+\paragraph{Time-independent Navier-Stokes equations} Recall that the Navier-Stokes equations model the flow of an incompresible viscous fluid filling a domain $\Omega\subset\R^3$, where the velocity $\vec v$ and the pressure $p$ satisfy
+\begin{align*}
+    \rho\left(\frac{\partial \vec v}{\partial t} + (\vx\vec v)\vec v\right) &= -\vx p + \mu\vx^2 \vec v + \vec f\\
+    \vx\cdot\vec v &= 0.
+\end{align*} 
+To perform our analysis, we assume that the fluid is in a steady state, that is, $\frac{\partial \vec v}{\partial t} = 0$, and enforcing homogeneous boundary conditions $\vec v = \vec 0$ we rewrite the system as 
+\begin{align*}
+    -\mu\vx^2\vec v + \rho (\vx\vec v)\vec v + \vx p &= \vec f\;\tin \Omega\\
+    \vx\cdot\vec v &= 0 \;\tin \Omega\\
+    \vec v &= 0 \;\ton \partial\Omega.
+\end{align*} 
+We can further simplify this problem by writing $\vec f\leftarrow \vec f / \rho$, $\lambda = p/\rho$ and $\nu = \mu/\rho$, which results in the system
+\begin{align*}
+    -\nu \vx^2\vec v + (\vx\vec v)\vec v + \vx \lambda &= \vec f\;\tin \Omega\\
+    \vx\cdot\vec v &= 0 \;\tin \Omega\\
+    \vec v &= 0 \;\ton \partial\Omega.  
+\end{align*}
+This system can be analyzed through Brouwer's fixed-point theorem, as detailed in \cite{ciarlet2013linear}.
+\begin{theorem}[Existence of a solution to the Navier-Stokes equations]
+    Let $\Omega\subset\R^3$ be a bounded Lipschitz domain, $\nu>0$ a positive constant and $\vec f\in H^{-1}(\Omega)$ be given. Then, there exists a solution $(\vec v, \lambda)\in (H_0^1(\Omega))^3\times L^2(\Omega)$ to the time-independent Navier-Stokes equations. Further, if a given $\vec u\in (H_0^1(\Omega))^3$ is such that $(\vec u, \lambda)$ is a solution to this problem, then $\lambda$ is unique. 
+    \begin{proof}
+        The full proof is detailed in \cite{ciarlet2013linear}, and we only outline the important steps here. For any $\vec v \in (H_0^1(\Omega))^3$, we arrive at the weak form
+        \begin{align*}
+            a(\vec u, \vec v) + b(\vec u; \vec u,\vec v) - \int_\Omega\lambda\dive\vec vdv &= \ell(\vec v)\\
+            \dive\vec u &= 0,
+        \end{align*}
+        where we defined 
+        \begin{align*}
+            a(\vec u, \vec v) &:= \nu\int_\Omega \nabla\vec u:\nabla\vec v dv,\\
+            b(\vec w; \vec u,\vec v) &:= \int_\Omega ((\nabla\vec u)\vec w)\cdot\vec v dv,\\
+            \ell(\vec v) &:=  \int_\Omega \vec f\cdot\vec v dv = \langle \vec f, \vec v\rangle_{H^{-1}(\Omega), H_0^1(\Omega)}.
+        \end{align*}
+        The bilinear form $a$ is clearly continuous, and $b$ is continuous by Holder's inequality and the Sobolev embedding theorem. We define the space $V(\Omega) = \{\vec v \in(H_0^1(\Omega))^3: \dive\vec v = 0\}$, which is a closed subspace of $(H_0^1(\Omega))^3$, making it a separable Hilbert space, and thus there exists a Hilbert basis $(\vec w_i)_{i=1}^\infty$ of $V(\Omega)$, from which we define the truncated space $\vec V^n := \text{span}(\vec w_i)_{i=1}^n$, and given any element $\vec w\in\vec V^n$, we can construct the (unique) functional $\vec F^n(\vec w)\in \vec V^n$ such that 
+        \begin{equation*}
+            (\vec F^n(\vec w), \vec v)_{1,\Omega} = a(\vec w, \vec v) + b(\vec w; \vec w, \vec v) - \ell(\vec v) \qquad \forall \vec v\in\vec V^n.
+        \end{equation*}
+        This operator is continuous, and setting $\vec v =\vec w$, with $b(\vec w;\vec w, \vec w) = 0$, we deduce 
+        \begin{equation*}
+            (\vec F^n(\vec w), \vec w)_{1,\Omega} = a(\vec w, \vec w) - \ell(\vec w) \geq \nu|\vec w|^2_{1,\Omega} - \|\vec f\|_{H^{-1}(\Omega)}|\vec w|_{1,\Omega},
+        \end{equation*}
+        and consequently for all $\vec w\in\vec V^n$ such that $|\vec w|_{1,\Omega} = \nu^{-1}\|\vec f\|_{H^{-1}(\Omega)}$, we have $(\vec F^n(\vec w), \vec w)_{1,\Omega} \geq 0$. Thus, by the Brouwer fixed-point theorem, there exists a solution $\vec u^n\in\vec V^n$ such that 
+        \begin{equation*}
+            a(\vec u^n, \vec v) + b(\vec u^n; \vec u^n, \vec v)  = \ell(\vec v), \qquad \forall \vec v\in\vec V^n,
+        \end{equation*}
+        with $|\vec u^n|_{1,\Omega} = \nu^{-1}\|\vec f\|_{H^{-1}(\Omega)}$. Taking limits as $n\to\infty$ we obtain a velocity solution $\vec u\in\vec V(\Omega)$ and using the injectivity of the gradient operator, we conclude that the corresponding $\lambda$ is unique. 
+    \end{proof}
+\end{theorem}
+Note that this is a only a special case of existence, and uniqueness is not ensured for the velocity field. There are some cases where we can prove uniqueness when the number $\nu^{-2}\|\vec f\|_{H^{-1}(\Omega)}$ is small enough, but in general, the Navier-Stokes equations are known to be ill-posed, and thus it is not possible to prove existence and uniqueness of solutions in all cases.
 \bibliography{main}
 \bibliographystyle{alpha}
 \end{document}

--- a/main.tex
+++ b/main.tex
@@ -3886,7 +3886,7 @@ This system can be analyzed through Brouwer's fixed-point theorem, as detailed i
 \begin{theorem}[Existence of a solution to the Navier-Stokes equations]
     Let $\Omega\subset\R^3$ be a bounded Lipschitz domain, $\nu>0$ a positive constant and $\vec f\in H^{-1}(\Omega)$ be given. Then, there exists a solution $(\vec v, \lambda)\in (H_0^1(\Omega))^3\times L^2(\Omega)$ to the time-independent Navier-Stokes equations. Further, if a given $\vec u\in (H_0^1(\Omega))^3$ is such that $(\vec u, \lambda)$ is a solution to this problem, then $\lambda$ is unique. 
     \begin{proof}
-        The full proof is detailed in \cite{ciarlet2013linear}, and we only outline the important steps here. For any $\vec v \in (H_0^1(\Omega))^3$, we arrive at the weak form
+        The full proof is detailed in \cite{ciarlet2013linear} (section 9.11), and we only outline the important steps here. For ease of notation, we write $\nabla$ instead of $\vx$. We multiply the equation above by $\vec v \in (H_0^1(\Omega))^3$ and integrate, yielding the weak form
         \begin{align*}
             a(\vec u, \vec v) + b(\vec u; \vec u,\vec v) - \int_\Omega\lambda\dive\vec vdv &= \ell(\vec v)\\
             \dive\vec u &= 0,


### PR DESCRIPTION
Hola Nico,

Agregué en esta PR los casos de análisis de las ecuaciones de elastostática y de existencia/unicidad para Navier-Stokes según lo que está en el Ciarlet y lo que hicimos en la tarea del año pasado (no fui muy extenso en esta parte). También incluí la demostración de la clase 5 Federico del Cauchy stress theorem.

Por favor, cuéntame cómo sigo, si quieres que introduzca otros ejemplos en la parte de mecánica del continuo (e.g. hiperelasticidad y el paper de Ball), o si veo alguna otra sección; esta PR tiene harto menos contenido que la anterior. Está en blanco la sección de Faedo-Galerkin y el método de líneas por si ves bueno seguir con eso. 

Estoy atento, saludos!